### PR TITLE
Update for KSP 1.8+

### DIFF
--- a/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version
+++ b/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version
@@ -12,25 +12,25 @@
     {
         "MAJOR":0,
         "MINOR":2,
-        "PATCH":6,
-        "BUILD":2
+        "PATCH":7,
+        "BUILD":1
     },
     "KSP_VERSION":
     {
         "MAJOR":1,
-        "MINOR":7,
-        "PATCH":3
+        "MINOR":8,
+        "PATCH":0
     },
     "KSP_VERSION_MIN":
     {
         "MAJOR":1,
-        "MINOR":4,
+        "MINOR":8,
         "PATCH":0
     },
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
-        "MINOR":7,
-        "PATCH":9
+        "MINOR":8,
+        "PATCH":99
     }
 } 

--- a/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version
+++ b/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version
@@ -13,13 +13,13 @@
         "MAJOR":0,
         "MINOR":2,
         "PATCH":6,
-        "BUILD":1
+        "BUILD":2
     },
     "KSP_VERSION":
     {
         "MAJOR":1,
-        "MINOR":4,
-        "PATCH":1
+        "MINOR":7,
+        "PATCH":3
     },
     "KSP_VERSION_MIN":
     {
@@ -30,7 +30,7 @@
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
-        "MINOR":4,
-        "PATCH":999
+        "MINOR":7,
+        "PATCH":9
     }
 } 

--- a/PlanetShine/PlanetShine.csproj
+++ b/PlanetShine/PlanetShine.csproj
@@ -7,8 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PlanetShine</RootNamespace>
     <AssemblyName>PlanetShine</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ReleaseVersion>0.2.2</ReleaseVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/PlanetShine/Utils/Utils.cs
+++ b/PlanetShine/Utils/Utils.cs
@@ -23,9 +23,11 @@ namespace PlanetShine
             GameObject obj = new GameObject ("Line");
             LineRenderer line = obj.AddComponent< LineRenderer > ();
             line.material = new Material (Shader.Find ("Particles/Additive"));
-            line.SetColors (startColor, endColor);
-            line.SetWidth (0.05f, 0.05f); 
-            line.SetVertexCount (2);
+            line.endColor = endColor;
+            line.startColor = startColor;
+            line.startWidth = 0.05f;
+            line.endWidth = 0.05f;
+            line.positionCount = 2;
             return line;
         }
 


### PR DESCRIPTION
Work fine on KSP 1.7.3, without any visible error or crash and produce the desired effects. So I propose to update it to the latest KSP version to enable CKAN user to use it without the need for "KSP version compatibility override".

I also update LineRender initialization to remove the deprecated function calls.